### PR TITLE
fix: upgrade `@guidepup/setup-action` for recording fixes

### DIFF
--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -17,11 +17,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16
-      - run: |
-          "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1440 900
-          sleep 5
       - name: Guidepup Setup
-        uses: guidepup/setup-action@0.3.1
+        uses: guidepup/setup-action@0.3.2
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 16
       - name: Guidepup Setup
-        uses: guidepup/setup-action@0.3.3
+        uses: guidepup/setup-action@0.3.4
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 16
       - name: Guidepup Setup
-        uses: guidepup/setup-action@0.3.4
+        uses: guidepup/setup-action@0.4.0
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 16
       - name: Guidepup Setup
-        uses: guidepup/setup-action@0.3.2
+        uses: guidepup/setup-action@0.3.3
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16
+      - run: "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1440 900 && sleep 5
       - name: Guidepup Setup
         uses: guidepup/setup-action@0.3.1
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16
-      - run: "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1440 900 && sleep 5
+      - run: |
+          "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1440 900
+          sleep 5
       - name: Guidepup Setup
         uses: guidepup/setup-action@0.3.1
       - run: yarn install --frozen-lockfile

--- a/tests/alert.spec.ts
+++ b/tests/alert.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from "@playwright/test";
+import { assert } from "./assert";
 import { voTest as test } from "@guidepup/playwright";
 import { record, setup } from "./setup";
 
@@ -20,21 +20,21 @@ test.describe("Alert", () => {
   test("Trigger an alert [1]", async ({ voiceOver }) => {
     await voiceOver.act();
 
-    expect(voiceOver.spokenPhraseLog()).toContain("Hello");
-    // expect(voiceOver.spokenPhraseLog()).toContain("alert");
+    assert({ voiceOver, phrase: "Hello" });
+    // assert({ voiceOver, phrase: "alert" });
   });
 
   test("Trigger an alert [2]", async ({ voiceOver }) => {
     await voiceOver.press("Space");
 
-    expect(voiceOver.spokenPhraseLog()).toContain("Hello");
-    // expect(voiceOver.spokenPhraseLog()).toContain("alert");
+    assert({ voiceOver, phrase: "Hello" });
+    // assert({ voiceOver, phrase: "alert" });
   });
 
   test("Trigger an alert [3]", async ({ voiceOver }) => {
     await voiceOver.press("Enter");
 
-    expect(voiceOver.spokenPhraseLog()).toContain("Hello");
-    // expect(voiceOver.spokenPhraseLog()).toContain("alert");
+    assert({ voiceOver, phrase: "Hello" });
+    // assert({ voiceOver, phrase: "alert" });
   });
 });

--- a/tests/alert.spec.ts
+++ b/tests/alert.spec.ts
@@ -20,21 +20,21 @@ test.describe("Alert", () => {
   test("Trigger an alert [1]", async ({ voiceOver }) => {
     await voiceOver.act();
 
-    expect(await voiceOver.lastSpokenPhrase()).toContain("Hello");
-    // expect(await voiceOver.lastSpokenPhrase()).toContain("alert");
+    expect(voiceOver.spokenPhraseLog()).toContain("Hello");
+    // expect(voiceOver.spokenPhraseLog()).toContain("alert");
   });
 
   test("Trigger an alert [2]", async ({ voiceOver }) => {
     await voiceOver.press("Space");
 
-    expect(await voiceOver.lastSpokenPhrase()).toContain("Hello");
-    // expect(await voiceOver.lastSpokenPhrase()).toContain("alert");
+    expect(voiceOver.spokenPhraseLog()).toContain("Hello");
+    // expect(voiceOver.spokenPhraseLog()).toContain("alert");
   });
 
   test("Trigger an alert [3]", async ({ voiceOver }) => {
     await voiceOver.press("Enter");
 
-    expect(await voiceOver.lastSpokenPhrase()).toContain("Hello");
-    // expect(await voiceOver.lastSpokenPhrase()).toContain("alert");
+    expect(voiceOver.spokenPhraseLog()).toContain("Hello");
+    // expect(voiceOver.spokenPhraseLog()).toContain("alert");
   });
 });

--- a/tests/assert.ts
+++ b/tests/assert.ts
@@ -1,0 +1,23 @@
+import { expect } from "@playwright/test";
+
+export function assert({ voiceOver, phrase, range = 2 }) {
+  const acceptableSpokenPhraseLog = voiceOver
+    .spokenPhraseLog()
+    .slice(-1 * range);
+
+  const found = !!acceptableSpokenPhraseLog.find((spokenPhrase) =>
+    spokenPhrase.includes(phrase)
+  );
+
+  if (!found) {
+    console.error(
+      `Unable to find phrase "${phrase}" in spoken phrase log:\n\n${JSON.stringify(
+        acceptableSpokenPhraseLog,
+        undefined,
+        2
+      )}`
+    );
+  }
+
+  expect(found).toBeTruthy();
+}

--- a/tests/banner.spec.ts
+++ b/tests/banner.spec.ts
@@ -1,6 +1,6 @@
-import { expect } from "@playwright/test";
 import { voTest as test } from "@guidepup/playwright";
 import { record, setup } from "./setup";
+import { assert } from "./assert";
 
 const testUrl =
   "https://aria-at.netlify.app/tests/banner/reference/2021-10-24_135455/banner.setfocusbeforebanner";
@@ -23,8 +23,9 @@ test.describe("Banner", () => {
     await voiceOver.next();
     await voiceOver.next();
 
-    expect(voiceOver.spokenPhraseLog()).toContain("Top link");
-    expect(voiceOver.spokenPhraseLog()).toContain("banner");
+    assert({ voiceOver, phrase: "Top" });
+    assert({ voiceOver, phrase: "link" });
+    assert({ voiceOver, phrase: "banner", range: 4 });
   });
 
   test("Navigate forwards into a banner landmark [2]", async ({
@@ -32,7 +33,8 @@ test.describe("Banner", () => {
   }) => {
     await voiceOver.perform(voiceOver.keyboard.commands.findNextLink);
 
-    expect(voiceOver.spokenPhraseLog()).toContain("Top link");
-    // expect(voiceOver.spokenPhraseLog()).toContain("banner");
+    assert({ voiceOver, phrase: "Top" });
+    assert({ voiceOver, phrase: "link" });
+    // assert({ voiceOver, phrase: "banner", range: 4 });
   });
 });

--- a/tests/banner.spec.ts
+++ b/tests/banner.spec.ts
@@ -23,7 +23,7 @@ test.describe("Banner", () => {
     await voiceOver.next();
     await voiceOver.next();
 
-    expect(voiceOver.spokenPhraseLog()).toContain("Top, link");
+    expect(voiceOver.spokenPhraseLog()).toContain("Top link");
     expect(voiceOver.spokenPhraseLog()).toContain("banner");
   });
 
@@ -32,7 +32,7 @@ test.describe("Banner", () => {
   }) => {
     await voiceOver.perform(voiceOver.keyboard.commands.findNextLink);
 
-    expect(voiceOver.spokenPhraseLog()).toContain("Top, link");
+    expect(voiceOver.spokenPhraseLog()).toContain("Top link");
     // expect(voiceOver.spokenPhraseLog()).toContain("banner");
   });
 });

--- a/tests/banner.spec.ts
+++ b/tests/banner.spec.ts
@@ -23,9 +23,8 @@ test.describe("Banner", () => {
     await voiceOver.next();
     await voiceOver.next();
 
-    expect(voiceOver.spokenPhraseLog().at(-1)).toContain("Top");
-    expect(voiceOver.spokenPhraseLog().at(-1)).toContain("link");
-    expect(voiceOver.spokenPhraseLog().at(-2)).toContain("banner");
+    expect(voiceOver.spokenPhraseLog()).toContain("Top, link");
+    expect(voiceOver.spokenPhraseLog()).toContain("banner");
   });
 
   test("Navigate forwards into a banner landmark [2]", async ({
@@ -33,8 +32,7 @@ test.describe("Banner", () => {
   }) => {
     await voiceOver.perform(voiceOver.keyboard.commands.findNextLink);
 
-    expect(voiceOver.spokenPhraseLog().at(-1)).toContain("Top");
-    expect(voiceOver.spokenPhraseLog().at(-1)).toContain("link");
-    // expect(voiceOver.spokenPhraseLog().at(-2)).toContain("banner");
+    expect(voiceOver.spokenPhraseLog()).toContain("Top, link");
+    // expect(voiceOver.spokenPhraseLog()).toContain("banner");
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -17,6 +17,10 @@ export async function record({ test }): Promise<() => void> {
 
 export async function setup({ page, testUrl, voiceOver }): Promise<void> {
   await page.goto(testUrl);
+  await delay(50);
+
+  await voiceOver.stopInteracting();
+  await voiceOver.stopInteracting();
   await voiceOver.stopInteracting();
   await voiceOver.interact();
 


### PR DESCRIPTION
Upgrades the `@guidepup/setup-action` to fix resolution issues with macos-11.

See https://github.com/actions/runner-images/issues/5960.

Also adjusts tests to harden them to variations in VoiceOver across different OS releases.