### PR TITLE
refactor: switch to new package `@guidepup/record`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@guidepup/guidepup": "^0.23.0",
     "@guidepup/playwright": "^0.14.0",
+    "@guidepup/record": "^0.1.0",
     "@playwright/test": "^1.45.3",
     "csvtojson": "^2.0.10",
     "playwright-merge-html-reports": "^0.2.8"

--- a/src/record.ts
+++ b/src/record.ts
@@ -1,4 +1,4 @@
-import { macOSRecord, windowsRecord } from "@guidepup/guidepup";
+import { macOSRecord, windowsRecord } from "@guidepup/record";
 import { test as playwrightTest } from "@playwright/test";
 import { platform, release } from "os";
 import { join } from "path";

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,6 +66,13 @@
   resolved "https://registry.yarnpkg.com/@guidepup/playwright/-/playwright-0.14.0.tgz#9c955d3a4816a6dde7d0261be1568d2f52cf8984"
   integrity sha512-hsiPTQMeA0vK0i5FXS2X8Yd+SJvfXoiCyWSeoYc0WhVPaMX22FjWt04PZREZA9PURo/zGXj+KVwgzEW60DYjLQ==
 
+"@guidepup/record@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@guidepup/record/-/record-0.1.0.tgz#03acb4286aab208037a4d5ef65fc2f5615ce485f"
+  integrity sha512-jtSqZ0CZVdWzWIbLWHYoUi1IbNJVKns20oEYzwcTftw8rY5RXsK1OTXaXFx9Gup5mnmYaFLnON8WwTS+4DYwrQ==
+  dependencies:
+    ffmpeg-static "^5.2.0"
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"


### PR DESCRIPTION
If I'm not mistaken, this would need to get switched to the new [`@guidepup/record`](https://www.npmjs.com/package/@guidepup/record) package as well, compare to e.g. https://www.guidepup.dev/docs/api/class-guidepup-record