### PR TITLE
refactor: updating GH actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
       - run: yarn install --frozen-lockfile
       - run: yarn ci

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -24,7 +24,7 @@ jobs:
     name: MacOS Install
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -72,7 +72,7 @@ jobs:
     name: Windows Install
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -126,7 +126,7 @@ jobs:
         shardIndex: [1]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -190,7 +190,7 @@ jobs:
         shardIndex: [1]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -271,7 +271,7 @@ jobs:
           sudo apt-get autoremove -y
           sudo apt-get clean
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
 
       - name: Cache node_modules
         uses: actions/cache@v3
@@ -76,9 +76,9 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
 
       - name: Cache node_modules
         uses: actions/cache@v3
@@ -130,9 +130,9 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
 
       - name: Guidepup Setup
         uses: guidepup/setup-action@0.13.0
@@ -194,9 +194,9 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
 
       - name: Guidepup Setup
         uses: guidepup/setup-action@0.13.0
@@ -275,9 +275,9 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
 
       - name: Update Deployment Status - Start
         uses: bobheadxi/deployments@v1

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
 
       - name: Cache node_modules
         uses: actions/cache@v3
@@ -76,9 +76,9 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
 
       - name: Cache node_modules
         uses: actions/cache@v3
@@ -152,9 +152,9 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
 
       - name: Guidepup Setup
         uses: guidepup/setup-action@0.13.0
@@ -238,9 +238,9 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
 
       - name: Guidepup Setup
         uses: guidepup/setup-action@0.13.0
@@ -319,9 +319,9 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
 
       - name: Update Deployment Status - Start
         uses: bobheadxi/deployments@v1

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -24,7 +24,7 @@ jobs:
     name: MacOS Install
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -72,7 +72,7 @@ jobs:
     name: Windows Install
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -148,7 +148,7 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -234,7 +234,7 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -315,7 +315,7 @@ jobs:
           sudo apt-get autoremove -y
           sudo apt-get clean
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
- [actions/setup-node](https://github.com/actions/setup-node/releases/tag/v4.0.0)
  - ✅ update to node 20
- [actions/checkout](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v400)
  - ✅ update to node 20

Plus we could target for the node version defined in `.nvmrc` directly.